### PR TITLE
fix: update Angular 21 peer dependencies

### DIFF
--- a/libs/mat-tel-input/package.json
+++ b/libs/mat-tel-input/package.json
@@ -34,12 +34,13 @@
     "tslib": "^2.x"
   },
   "peerDependencies": {
-    "@angular/common": "19.x",
-    "@angular/core": "19.x",
-    "@angular/material": "19.x",
-    "@angular/forms": "19.x",
-    "@angular/platform-browser": "19.x",
-    "@angular/platform-browser-dynamic": "19.x",
+    "@angular/cdk": "21.x",
+    "@angular/common": "21.x",
+    "@angular/core": "21.x",
+    "@angular/forms": "21.x",
+    "@angular/material": "21.x",
+    "@angular/platform-browser": "21.x",
+    "@angular/platform-browser-dynamic": "21.x",
     "libphonenumber-js": "^1.11.16"
   }
 }


### PR DESCRIPTION
## Summary
- update the published library peer dependencies from Angular 19 to Angular 21
- add the missing @angular/cdk peer dependency used by the component

## Validation
- yarn nx build mat-tel-input
- yarn nx test mat-tel-input
- yarn nx lint mat-tel-input *(currently fails because of existing unrelated lint issues in the workspace)*

Closes #16