### PR TITLE
fix(mat-tel-input): required marker and submit error state for reactive forms

### DIFF
--- a/libs/mat-tel-input/src/lib/mat-tel-input.component.spec.ts
+++ b/libs/mat-tel-input/src/lib/mat-tel-input.component.spec.ts
@@ -1,4 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   FormControl,
   FormGroup,
@@ -6,11 +7,10 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatMenuTrigger } from '@angular/material/menu';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { Country } from './country.model';
 import { PhoneNumberFormat } from './mat-tel-format.model';
@@ -126,6 +126,37 @@ class NgModelHostComponent {
   @ViewChild(MatTelInput) matTelInput!: MatTelInput;
 }
 
+@Component({
+  standalone: true,
+  imports: [FormsModule, ReactiveFormsModule, MatFormFieldModule, MatTelInput],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <mat-form-field>
+        <mat-label>Phone number</mat-label>
+        <mat-tel-input
+          formControlName="phone"
+          [preferredCountries]="preferredCountries"
+        />
+        <mat-error>Field is required</mat-error>
+      </mat-form-field>
+      <button type="submit">submit</button>
+    </form>
+  `,
+})
+class ReactiveSubmitHostComponent {
+  form = new FormGroup({
+    phone: new FormControl<string | null>(null, {
+      validators: [Validators.required],
+    }),
+  });
+  preferredCountries: string[] = ['us'];
+  submitted = false;
+
+  onSubmit(): void {
+    this.submitted = true;
+  }
+}
+
 describe('MatTelInput', () => {
   async function stabilize<T>(fixture: ComponentFixture<T>) {
     fixture.detectChanges();
@@ -197,6 +228,7 @@ describe('MatTelInput', () => {
         NoopAnimationsModule,
         StandaloneHostComponent,
         ReactiveHostComponent,
+        ReactiveSubmitHostComponent,
         DirectFormControlHostComponent,
         NgModelHostComponent,
       ],
@@ -230,6 +262,38 @@ describe('MatTelInput', () => {
         ['tz', 'us'].includes(country.iso2),
       ),
     ).toBe(true);
+  });
+
+  it('should show the required marker when only Validators.required is used', async () => {
+    const fixture = TestBed.createComponent(ReactiveHostComponent);
+
+    await stabilize(fixture);
+
+    const marker = fixture.nativeElement.querySelector(
+      '.mat-mdc-form-field-required-marker',
+    );
+
+    expect(marker).toBeTruthy();
+  });
+
+  it('should show error state after reactive form submit when the field is invalid', async () => {
+    const fixture = TestBed.createComponent(ReactiveSubmitHostComponent);
+
+    await stabilize(fixture);
+
+    const submitButton = fixture.nativeElement.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+
+    submitButton.click();
+    await stabilize(fixture);
+
+    const invalidOutline = fixture.nativeElement.querySelector(
+      '.mdc-text-field--invalid',
+    );
+
+    expect(invalidOutline).toBeTruthy();
+    expect(fixture.componentInstance.submitted).toBe(true);
   });
 
   it('should propagate a valid national number to the reactive form as E.164', async () => {

--- a/libs/mat-tel-input/src/lib/mat-tel-input.component.ts
+++ b/libs/mat-tel-input/src/lib/mat-tel-input.component.ts
@@ -9,8 +9,8 @@ import {
   ElementRef,
   EventEmitter,
   HostBinding,
-  Input,
   Injector,
+  Input,
   OnDestroy,
   OnInit,
   Optional,
@@ -21,13 +21,13 @@ import {
   booleanAttribute,
 } from '@angular/core';
 import {
-  FormControl,
   FormGroupDirective,
   FormsModule,
   NG_VALIDATORS,
   NgControl,
   NgForm,
   ReactiveFormsModule,
+  Validators,
 } from '@angular/forms';
 import { ErrorStateMatcher, MatRippleModule } from '@angular/material/core';
 import { MatDividerModule } from '@angular/material/divider';
@@ -128,14 +128,18 @@ export class MatTelInput
     return this._format;
   }
 
-  private _required = false;
+  private _required?: boolean;
   @Input({ transform: booleanAttribute })
   set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next(undefined);
   }
   get required(): boolean {
-    return this._required;
+    return (
+      this._required ??
+      this.ngControl?.control?.hasValidator(Validators.required) ??
+      false
+    );
   }
 
   private _disabled = false;
@@ -232,21 +236,21 @@ export class MatTelInput
     this.stateChanges.next();
   }
 
-  updateErrorState() {
-    if (
-      this.ngControl &&
-      this.ngControl.invalid &&
-      (this.ngControl.touched ||
-        (this._parentForm && this._parentForm.submitted))
-    ) {
-      const currentState = this.errorStateMatcher.isErrorState(
-        this.ngControl.control as FormControl,
-        this.ngControl?.value,
-      );
-      if (currentState !== this.errorState) {
-        this.errorState = currentState;
-        this._changeDetectorRef.markForCheck();
-      }
+  updateErrorState(): void {
+    if (!this.ngControl) {
+      return;
+    }
+
+    const oldState = this.errorState;
+    const parent = this._parentFormGroup || this._parentForm;
+    const control = this.ngControl.control ?? null;
+    const newState =
+      this.errorStateMatcher.isErrorState(control, parent) ?? false;
+
+    if (newState !== oldState) {
+      this.errorState = newState;
+      this._changeDetectorRef.markForCheck();
+      this.stateChanges.next();
     }
   }
 
@@ -296,22 +300,7 @@ export class MatTelInput
 
   ngDoCheck(): void {
     if (this.ngControl) {
-      const oldState = this.errorState;
-      const newState = this.errorStateMatcher.isErrorState(
-        this.ngControl.control,
-        this._parentForm,
-      );
-
-      this.errorState =
-        (newState &&
-          (!this.ngControl.control?.value ||
-            this.ngControl.control?.touched)) ||
-        (!this.focused ? newState : false);
-
-      if (oldState !== newState) {
-        this.errorState = newState;
-        this.stateChanges.next();
-      }
+      this.updateErrorState();
     }
   }
 


### PR DESCRIPTION
## Summary

Aligns `MatTelInput` with Angular Material `MatInput` for reactive forms:

- **Required asterisk**: `MatFormFieldControl.required` now reflects `Validators.required` on the bound control when the template does not set `required`.
- **Error state on submit**: `ErrorStateMatcher.isErrorState` receives `FormGroupDirective` or `NgForm` (same as Material’s `_ErrorStateTracker`), so invalid styling and `mat-error` appear after submit without needing `markAllAsTouched()`.

## Tests

- Required marker with only `Validators.required`
- Invalid outline after reactive `ngSubmit` with empty required phone

Fixes https://github.com/Muneersahel/mat-tel-input/issues/28  
Closes https://github.com/Muneersahel/mat-tel-input/issues/28